### PR TITLE
Fix logger messages

### DIFF
--- a/src/main/scala/com/feedzai/cosytest/DockerComposeSetup.scala
+++ b/src/main/scala/com/feedzai/cosytest/DockerComposeSetup.scala
@@ -196,7 +196,7 @@ case class DockerComposeSetup(
       Await.result(future, timeout)
     } catch {
       case e: TimeoutException =>
-        e.printStackTrace()
+        logger.error(s"Container $containerId didn't change to healthy state in ${timeout.toSeconds} seconds", e)
         false
     }
   }
@@ -244,7 +244,7 @@ case class DockerComposeSetup(
       Await.result(future, timeout)
     } catch {
       case e: TimeoutException =>
-        e.printStackTrace()
+        logger.error(s"Process didn't finish in ${timeout.toSeconds} seconds", e)
         process.destroy()
         process.exitValue()
     }

--- a/src/main/scala/com/feedzai/cosytest/DockerComposeTestSuite.scala
+++ b/src/main/scala/com/feedzai/cosytest/DockerComposeTestSuite.scala
@@ -74,9 +74,8 @@ trait DockerComposeTestSuite extends TestSuite with BeforeAndAfterAll {
           logger.info("Removing containers...")
           val removed = setup.down()
           assert(removed, s"Failed to remove containers in test ${setup.setupName}!")
-
+          logger.info("Containers removed!")
         }
-        logger.info("Containers removed!")
       }
     } finally { parallelTestLimitSemaphore.release() }
   }


### PR DESCRIPTION
* Fixed logger in DockerComposeTestSuite to just log when actually containers are removed
* Replaced printStackTrace invocations with logger errors.