### PR TITLE
Add testng support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.4" % Provided,
   "io.gatling" % "gatling-test-framework" % "2.2.5" % Provided,
   "com.novocode" % "junit-interface" % "0.11" % Provided,
-  "org.hamcrest" % "hamcrest-junit" % "2.0.0.0" % Test
+  "org.hamcrest" % "hamcrest-junit" % "2.0.0.0" % Test,
+  "org.testng" % "testng" % "6.14.2" % Provided
 )
 
 /* Extra metadata for releases */

--- a/src/main/scala/com/feedzai/cosytest/DockerComposeJavaManager.java
+++ b/src/main/scala/com/feedzai/cosytest/DockerComposeJavaManager.java
@@ -1,0 +1,164 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without prior permission of the owner.
+ *
+ * © 2018 Feedzai, Strictly Confidential
+ */
+
+package com.feedzai.cosytest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import scala.runtime.BoxedUnit;
+import scala.util.Try;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Utility class that provides container lifecycle management operations and configuration.
+ */
+public class DockerComposeJavaManager {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DockerComposeJavaSetup dockerSetup;
+
+    private final Duration containerStartUpTimeout;
+
+    private boolean keepContainersOnSuccess;
+    private boolean keepContainersOnFailure;
+
+    private Optional<Path> logDumpLocation;
+    private Optional<String> logDumpFileName;
+
+    private boolean testFailed;
+
+    DockerComposeJavaManager(final Builder builder) {
+        this.dockerSetup = builder.dockerSetup;
+        this.containerStartUpTimeout = builder.containerStartUpTimeout;
+        this.keepContainersOnSuccess = builder.keepContainersOnSuccess;
+        this.keepContainersOnFailure = builder.keepContainersOnFailure;
+        this.logDumpLocation = builder.logDumpLocation;
+        this.logDumpFileName = builder.logDumpFileName;
+        testFailed = false;
+    }
+
+    public boolean getKeepContainersOnSuccess() {
+        return keepContainersOnSuccess;
+    }
+
+    public boolean getKeepContainersOnFailure() {
+        return keepContainersOnFailure;
+    }
+
+    public Optional<Path> getLogDumpLocation() {
+        return logDumpLocation;
+    }
+
+    public Optional<String> getLogDumpFileName() {
+        return logDumpFileName;
+    }
+
+    public boolean getTestFailed() {
+        return testFailed;
+    }
+
+    public void setTestFailed(final boolean testFailed) {
+        this.testFailed = testFailed;
+    }
+
+    public void launchContainers() {
+        if (dockerSetup != null) {
+            logger.info("Starting containers...");
+            Boolean started = dockerSetup.up(containerStartUpTimeout);
+            if(!started) {
+                this.tearDownContainers();
+                Assert.fail("Failed to start containers for setup " + dockerSetup.setupName() + "!");
+            }
+            logger.info("Containers started!");
+        }
+    }
+
+    public void tearDownContainers() {
+        if (dockerSetup != null) {
+            if (testFailed && logDumpFileName.isPresent() && logDumpLocation.isPresent()) {
+                Try<BoxedUnit> dumpLogs = dockerSetup.dumpLogs(logDumpFileName.get(), logDumpLocation.get());
+                if (dumpLogs.isFailure()) {
+                    logger.error("Failed to dump logs!", dumpLogs.failed().get());
+                }
+            }
+
+            Boolean keep = (keepContainersOnSuccess && !testFailed) || (keepContainersOnFailure && testFailed);
+
+            if (!keep) {
+                logger.info("Removing containers...");
+                Boolean removed = dockerSetup.down();
+                assertThat(
+                        "Failed to remove containers for setup " + dockerSetup.setupName() + "!",
+                        removed,
+                        is(true)
+                );
+                logger.info("Containers removed!");
+            }
+        }
+    }
+
+    public static Builder builder(DockerComposeJavaSetup dockerSetup) {
+        return new Builder(dockerSetup);
+    }
+
+    public static class Builder {
+
+        DockerComposeJavaSetup dockerSetup;
+
+        Duration containerStartUpTimeout = Duration.ofMinutes(5);
+
+        boolean keepContainersOnSuccess = false;
+        boolean keepContainersOnFailure = false;
+
+        Optional<Path> logDumpLocation   = Optional.empty();
+        Optional<String> logDumpFileName = Optional.empty();
+
+        Builder(final DockerComposeJavaSetup manager) {
+            this.dockerSetup = manager;
+        }
+
+        public Builder withContainerStartUpTimeout(final Duration startUpTimeout) {
+            this.containerStartUpTimeout = startUpTimeout;
+            return this;
+        }
+
+        public Builder withKeepContainersOnSuccess(final boolean keepContainersOnSuccess) {
+            this.keepContainersOnSuccess = keepContainersOnSuccess;
+            return this;
+        }
+
+        public Builder withKeepContainersOnFailure(final boolean keepContainersOnFailure) {
+            this.keepContainersOnFailure = keepContainersOnFailure;
+            return this;
+        }
+
+        public Builder withLogDumpLocation(final Path logDumpLocation) {
+            this.logDumpLocation = Optional.of(logDumpLocation);
+            return this;
+        }
+
+        public Builder withLogDumpFileName(final String logDumpFileName) {
+            this.logDumpFileName = Optional.of(logDumpFileName);
+            return this;
+        }
+
+        public DockerComposeJavaManager build() {
+            return new DockerComposeJavaManager(this);
+        }
+
+    }
+}

--- a/src/test/scala/com/feedzai/cosytest/testng/IntegrationSpec.java
+++ b/src/test/scala/com/feedzai/cosytest/testng/IntegrationSpec.java
@@ -1,0 +1,76 @@
+package com.feedzai.cosytest.testng;
+
+import com.feedzai.cosytest.DockerComposeJavaManager;
+import com.feedzai.cosytest.DockerComposeJavaSetup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+
+public class IntegrationSpec {
+
+    private static Logger logger = LoggerFactory.getLogger(IntegrationSpec.class);
+
+    private DockerComposeJavaSetup dockerSetup;
+
+    private DockerComposeJavaManager containerManager;
+
+    @BeforeClass
+    public void init() {
+
+        dockerSetup = new DockerComposeJavaSetup(
+                "testngtest",
+                Collections.singletonList(Paths.get("src", "test", "resources", "docker-compose-junit.yml")),
+                Paths.get("").toAbsolutePath(),
+                new HashMap<>()
+        );
+
+        containerManager = DockerComposeJavaManager
+                .builder(dockerSetup)
+                .build();
+
+        containerManager.launchContainers();
+    }
+
+    @AfterMethod
+    public void checkTestResult(ITestResult result) {
+        if (result.getStatus() == ITestResult.FAILURE) {
+            containerManager.setTestFailed(true);
+        }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        containerManager.tearDownContainers();
+    }
+
+    @Test
+    public void fetchServices() {
+        assertThat(
+                dockerSetup.getServices(),
+                containsInAnyOrder("container1", "container2", "container3")
+        );
+    }
+
+    @Test
+    public void validateMappedPorts() {
+        assertThat(dockerSetup.getServiceMappedPort("container1", 80), contains("8084"));
+        assertThat(dockerSetup.getServiceMappedPort("container2", 80), contains("8085"));
+        assertThat(dockerSetup.getServiceMappedPort("container3", 80), contains("8086"));
+    }
+
+}
+
+


### PR DESCRIPTION
- Added DockerComposeJavaManager class that behaves similarly to DockerComposeRule but uses a Builder pattern for constructions, has the container lifecycle operations public and different method names.
- Added IntegrationSpec to test and validate TestNG support using non-static @BeforeClass @AfterMethod and @AfterClass annotations.