### PR TITLE
Add file copy to container/host support

### DIFF
--- a/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
+++ b/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
@@ -406,7 +406,7 @@ case class DockerComposeSetup(
       "docker",
       "cp",
       hostPath.toString,
-      Seq(containerId, ":", containerPath.toString).mkString
+      s"$containerId:${containerPath.toString}"
     )
 
     runCmdWithOutput(command, workingDirectory.toFile, environment, DefaultShortCommandTimeOut) match {

--- a/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
+++ b/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
@@ -401,12 +401,12 @@ case class DockerComposeSetup(
     * @param containerPath  Path to file destination in the container.
     * @return true if the file was copied successfully, otherwise false.
     */
-  def copyToContainer(containerId: String, hostPath: String, containerPath: String): Boolean = {
+  def copyToContainer(containerId: String, hostPath: Path, containerPath: Path): Boolean = {
     val command = Seq(
       "docker",
       "cp",
-      hostPath,
-      s"$containerId:$containerPath"
+      hostPath.toString,
+      Seq(containerId, ":", containerPath.toString).mkString
     )
 
     runCmdWithOutput(command, workingDirectory.toFile, environment, DefaultShortCommandTimeOut) match {
@@ -425,12 +425,12 @@ case class DockerComposeSetup(
     * @param containerPath  Path to file destination in the container.
     * @return true if the file was copied successfully, otherwise false.
     */
-  def copyToHost(containerId: String, hostPath: String, containerPath: String): Boolean = {
+  def copyToHost(containerId: String, hostPath: Path, containerPath: Path): Boolean = {
     val command = Seq(
       "docker",
       "cp",
-      s"$containerId:$containerPath",
-      hostPath
+      Seq(containerId, ":", containerPath.toString).mkString,
+      hostPath.toString
     )
 
     runCmdWithOutput(command, workingDirectory.toFile, environment, DefaultShortCommandTimeOut) match {

--- a/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
+++ b/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
@@ -421,11 +421,11 @@ case class DockerComposeSetup(
     * Copies a file from the container filesystem to the specified path in the host.
     *
     * @param containerId    Container identifier from which the file will be copied.
-    * @param hostPath       Path to file source in the host.
-    * @param containerPath  Path to file destination in the container.
+    * @param containerPath  Path to file source in the container.
+    * @param hostPath       Path to file destination in the host.
     * @return true if the file was copied successfully, otherwise false.
     */
-  def copyToHost(containerId: String, hostPath: Path, containerPath: Path): Boolean = {
+  def copyToHost(containerId: String, containerPath: Path, hostPath: Path): Boolean = {
     val command = Seq(
       "docker",
       "cp",

--- a/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
+++ b/src/main/scala/com/feedzai/cosytest/core/DockerComposeSetup.scala
@@ -394,6 +394,54 @@ case class DockerComposeSetup(
   }
 
   /**
+    * Copies a file from the host filesystem to the specified path in the container.
+    *
+    * @param containerId    Container identifier to which the file will be copied.
+    * @param hostPath       Path to file source in the host.
+    * @param containerPath  Path to file destination in the container.
+    * @return true if the file was copied successfully, otherwise false.
+    */
+  def copyToContainer(containerId: String, hostPath: String, containerPath: String): Boolean = {
+    val command = Seq(
+      "docker",
+      "cp",
+      hostPath,
+      s"$containerId:$containerPath"
+    )
+
+    runCmdWithOutput(command, workingDirectory.toFile, environment, DefaultShortCommandTimeOut) match {
+      case Success(output) => output.isEmpty
+      case Failure(f) =>
+        logger.error(s"Failed to copy file to container $containerId ", f.getCause)
+        false
+    }
+  }
+
+  /**
+    * Copies a file from the container filesystem to the specified path in the host.
+    *
+    * @param containerId    Container identifier from which the file will be copied.
+    * @param hostPath       Path to file source in the host.
+    * @param containerPath  Path to file destination in the container.
+    * @return true if the file was copied successfully, otherwise false.
+    */
+  def copyToHost(containerId: String, hostPath: String, containerPath: String): Boolean = {
+    val command = Seq(
+      "docker",
+      "cp",
+      s"$containerId:$containerPath",
+      hostPath
+    )
+
+    runCmdWithOutput(command, workingDirectory.toFile, environment, DefaultShortCommandTimeOut) match {
+      case Success(output) => output.isEmpty
+      case Failure(f) =>
+        logger.error(s"Failed to copy file to container $containerId ", f.getCause)
+        false
+    }
+  }
+
+  /**
     * Stops all containers.
     *
     * @param ids of the containers to be stopped

--- a/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
+++ b/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
@@ -1,6 +1,5 @@
 package com.feedzai.cosytest.core
 
-import java.io.File
 import java.nio.file.{Files, Paths}
 
 import com.feedzai.cosytest.{CleanUp, DockerComposeSetup, FileTools, Utils}
@@ -37,7 +36,6 @@ class ContainerFileCopySpec extends FlatSpec with MustMatchers with CleanUp {
     val copyFileDestination = Paths.get("/tmp/"+tempFile.getFileName.toString)
     setup.copyToHost(containerId, Paths.get("/opt/",tempFile.getFileName.toString), copyFileDestination) mustBe true
 
-    val copiedFile = new File(copyFileDestination.toAbsolutePath.toString)
     Source.fromFile(copyFileDestination.toFile).mkString mustEqual Source.fromFile(tempFile.toFile).mkString
 
     Files.delete(tempFile)

--- a/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
+++ b/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
@@ -2,7 +2,8 @@ package com.feedzai.cosytest.core
 
 import java.nio.file.{Files, Paths}
 
-import com.feedzai.cosytest.{CleanUp, DockerComposeSetup, FileTools, Utils}
+import com.feedzai.cosytest.utils.FileTools
+import com.feedzai.cosytest.{CleanUp, Utils}
 import org.scalatest.{FlatSpec, MustMatchers}
 
 import scala.io.Source

--- a/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
+++ b/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
@@ -1,7 +1,7 @@
 package com.feedzai.cosytest.core
 
-import java.io.{File}
-import java.nio.file.{Paths}
+import java.io.File
+import java.nio.file.{Files, Paths}
 
 import com.feedzai.cosytest.{CleanUp, DockerComposeSetup, FileTools, Utils}
 import org.scalatest.{FlatSpec, MustMatchers}
@@ -31,17 +31,18 @@ class ContainerFileCopySpec extends FlatSpec with MustMatchers with CleanUp {
     setup.dockerComposeUp()
     val containerId = setup.getProjectContainerIds().head
 
-    val tempFile = FileTools.createFile(Paths.get("newFile.txt"), List("some contents"))
-    setup.copyToContainer(containerId, tempFile.get, Paths.get("/opt")) mustBe true
+    val tempFile = FileTools.createFile(Paths.get("newFile.txt"), List("some contents")).get
+    setup.copyToContainer(containerId, tempFile, Paths.get("/opt")) mustBe true
 
-    val copyFileDestination = Paths.get(tempFile.get.getFileName.toString)
-    setup.copyToHost(containerId, copyFileDestination, Paths.get("/opt/",tempFile.get.getFileName.toString)) mustBe true
+    val copyFileDestination = Paths.get("/tmp/"+tempFile.getFileName.toString)
+    setup.copyToHost(containerId, Paths.get("/opt/",tempFile.getFileName.toString), copyFileDestination) mustBe true
 
-    val copiedFile = new File(copyFileDestination.toUri)
-    Source.fromFile(copyFileDestination.toFile).mkString mustEqual Source.fromFile(tempFile.get.toFile).mkString
+    val copiedFile = new File(copyFileDestination.toAbsolutePath.toString)
+    Source.fromFile(copyFileDestination.toFile).mkString mustEqual Source.fromFile(tempFile.toFile).mkString
 
-    tempFile.get.toFile.delete()
-    copiedFile.delete()
+    Files.delete(tempFile)
+    Files.delete(copyFileDestination)
+
     setup.dockerComposeDown()
   }
 

--- a/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
+++ b/src/test/scala/com/feedzai/cosytest/core/ContainerFileCopySpec.scala
@@ -1,0 +1,51 @@
+package com.feedzai.cosytest.core
+
+import java.io.{File, PrintWriter}
+import java.nio.file.Paths
+
+import com.feedzai.cosytest.{CleanUp, DockerComposeSetup, Utils}
+import org.scalatest.{FlatSpec, MustMatchers}
+
+import scala.io.Source
+
+class ContainerFileCopySpec extends FlatSpec with MustMatchers with CleanUp {
+
+  val setup = DockerComposeSetup(
+    Utils.randomSetupName,
+    Seq(Paths.get("src", "test", "resources", "docker-compose.yml")),
+    Paths.get("").toAbsolutePath,
+    Map.empty
+  )
+
+  override def dockerSetups = Seq(setup)
+
+  it should "Returns false if an exception is thrown while trying to handle non-existing files" in {
+    setup.dockerComposeUp()
+    val containerId = setup.getProjectContainerIds().head
+
+    setup.copyToContainer(containerId, "nonExistingFile", "/opt") mustBe false
+    setup.dockerComposeDown()
+  }
+
+  it should "Retrieve a file from a container that was previously copied into it" in {
+    setup.dockerComposeUp()
+    val fileContent = "some content"
+    val tempFile = File.createTempFile("tmp",".txt")
+    new PrintWriter(tempFile) { write(fileContent); close() }
+    val containerId = setup.getProjectContainerIds().head
+
+    setup.copyToContainer(containerId, tempFile.getAbsolutePath, "/opt") mustBe true
+
+    val copyFileDestination = ".";
+    setup.copyToHost(containerId, copyFileDestination, "/opt/"+tempFile.getName) mustBe true
+
+    val copiedFile = new File(copyFileDestination+"/"+tempFile.getName)
+
+    Source.fromFile(copiedFile).mkString mustEqual fileContent
+
+    tempFile.delete()
+    copiedFile.delete()
+    setup.dockerComposeDown()
+  }
+
+}


### PR DESCRIPTION
- Adds the possibility to copy files from/to a container during test execution and not only via the docker-compose file.
- Also includes feature tests. 