### PR TITLE
Changed testFailed flag scope in DockerComposeTestSuite

### DIFF
--- a/src/main/scala/com/feedzai/cosytest/scalatest/DockerComposeTestSuite.scala
+++ b/src/main/scala/com/feedzai/cosytest/scalatest/DockerComposeTestSuite.scala
@@ -27,11 +27,11 @@ trait DockerComposeTestSuite extends TestSuite with BeforeAndAfterAll {
   def containerStartUpTimeout: Option[Duration] = None
 
   /**
-   * Semaphore used to control the number of test running in parallel
+   * Semaphore used to control the number of tests running in parallel
    */
   def parallelTestLimitSemaphore: Semaphore = new Semaphore(1, true)
 
-  private var testFailed: Boolean = false
+  protected var testFailed: Boolean = false
 
   protected abstract override def runTest(testName: String, args: Args): Status = {
     val result = super.runTest(testName, args)


### PR DESCRIPTION
* Changed testFailed flag scope to protected in order to classes
extending from DockerComposeTestSuite be able to access its value.